### PR TITLE
Add ca certificates

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -23,8 +23,15 @@ parts:
     build-environment:
       - GOFLAGS: -ldflags=-w -ldflags=-s
       - CGO_ENABLED: 0
+    build-packages:
+      - ca-certificates
     source: https://github.com/ory/kratos
     source-type: git
     source-tag: v0.13.0
-    stage:
-      - bin/kratos
+    override-build: |
+      mkdir -p ${CRAFT_PART_INSTALL}/etc/ssl/certs
+
+      go mod download
+      go build -o ${CRAFT_PART_INSTALL}/bin/kratos
+
+      cp -r /etc/ssl/certs ${CRAFT_PART_INSTALL}/etc/ssl/

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -23,15 +23,11 @@ parts:
     build-environment:
       - GOFLAGS: -ldflags=-w -ldflags=-s
       - CGO_ENABLED: 0
-    build-packages:
-      - ca-certificates
     source: https://github.com/ory/kratos
     source-type: git
     source-tag: v0.13.0
     override-build: |
-      mkdir -p ${CRAFT_PART_INSTALL}/etc/ssl/certs
-
       go mod download
       go build -o ${CRAFT_PART_INSTALL}/bin/kratos
-
-      cp -r /etc/ssl/certs ${CRAFT_PART_INSTALL}/etc/ssl/
+    stage-packages:
+      - ca-certificates_data


### PR DESCRIPTION
Add the trusted ca certificates to the final image. 

I tried using the overlay part to install the ca-certificates package directly the final image, but I could not run apt-get (probably because it tries to run in the `bare` image). 

Should we consider switching to an ubuntu base to avoid any similar issues in the future? 

Closes #5