### PR TITLE
Add sh and tee packages

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -30,4 +30,8 @@ parts:
       go mod download
       go build -o ${CRAFT_PART_INSTALL}/bin/kratos
     stage-packages:
-      - ca-certificates_data
+      # We cannot mix packages and slices, so we can't use the `ca-certificates_data` slice
+      - ca-certificates
+      # These packages are needed to pipe the stdout/stderr to a file, which is needed for log forwarding
+      - dash
+      - coreutils


### PR DESCRIPTION
Add the `dash` and `tee` packages that are needed for our COS integration.