### PR TITLE
feat: add run-user field to run container with a well-defined user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,21 @@
 kratos_*.rock
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen
+
+# VisualStudioCode template
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -6,6 +6,7 @@ summary: Ory Kratos identity server
 description: |
   Ory Kratos is an Identity and User Management system.
 license: Apache-2.0
+run-user: _daemon_
 platforms:
   amd64:
 


### PR DESCRIPTION
### Overview

Add the `run-user` field to the `rockcraft.yaml` file in order to run container with a well-defined user `_daemon_`. The spec can be found [HERE](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/reference/rockcraft.yaml.html#run-user). The rationale can be found [HERE](https://docs.google.com/document/d/18OQ8MN2Qak65CzTj5QAjLxrw6bt1UaoC31kIkSwDRz8/edit).

### Testing Locally

- Build the ROCK image using the `rockcraft` tool
- Either do `docker inspect <image name>:<image tag> | jq '.[].Config.User'` to inspect the image, or [run the container](https://canonical-rockcraft.readthedocs-hosted.com/en/latest/tutorials/hello-world.html#run-the-rock-in-docker) and do `docker inspect $(docker ps -q) --format '{{.Config.User}} {{.Name}}'`