### PR TITLE
Add ca-certificates_data

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -58,3 +58,5 @@ parts:
 
       go mod download
       go build -ldflags="${go_linker_flags}" -o ${CRAFT_PART_INSTALL}/bin/kratos
+    stage-packages:
+      - ca-certificates_data


### PR DESCRIPTION
In the current published version the rock, the `/etc/ssl/certs/` folder is empty.

Closes #24
