### PR TITLE
IAM-483-Enable update-ca-certificates 

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -33,8 +33,32 @@ parts:
 
   certificates:
     plugin: nil
-    stage-packages:
+    build-packages:
       - ca-certificates
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/etc/ssl/certs
+      mkdir -p $CRAFT_PART_INSTALL/usr/share/ca-certificates/mozilla/
+      mkdir -p $CRAFT_PART_INSTALL/usr/sbin
+      touch $CRAFT_PART_INSTALL/etc/ssl/certs/ca-certificates.crt
+      touch $CRAFT_PART_INSTALL/etc/ca-certificates.conf
+      for cert in /usr/share/ca-certificates/mozilla/* ; do
+        echo "mozilla/$(basename $cert)" >> $CRAFT_PART_INSTALL/etc/ca-certificates.conf
+        cat "$cert" >> $CRAFT_PART_INSTALL/etc/ssl/certs/ca-certificates.crt
+      done
+      cp /usr/share/ca-certificates/mozilla/* $CRAFT_PART_INSTALL/usr/share/ca-certificates/mozilla
+      cp /usr/sbin/update-ca-certificates $CRAFT_PART_INSTALL/usr/sbin/update-ca-certificates
+
+  sed:
+    plugin: nil
+    stage-packages:
+      - sed
+  
+  find:
+    plugin: nil
+    stage-packages:
+      - findutils
+    prime:
+      - usr/bin/find
 
   kratos:
     plugin: go
@@ -58,5 +82,3 @@ parts:
 
       go mod download
       go build -ldflags="${go_linker_flags}" -o ${CRAFT_PART_INSTALL}/bin/kratos
-    stage-packages:
-      - ca-certificates_data

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -20,10 +20,14 @@ parts:
   util:
     plugin: nil
     stage-packages:
-      # This is needed to pipe the stdout/stderr to a file for log forwarding
+      # This is needed to pipe the stdout/stderr to a file for log forwarding and to update certificates
       - coreutils
-    prime:
-      - usr/bin/tee
+  
+  openssl:
+    plugin: nil
+    stage-packages:
+      # This is needed to update certificates
+      - openssl
 
   shell:
     plugin: nil
@@ -39,6 +43,8 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/etc/ssl/certs
       mkdir -p $CRAFT_PART_INSTALL/usr/share/ca-certificates/mozilla/
       mkdir -p $CRAFT_PART_INSTALL/usr/sbin
+      mkdir -p $CRAFT_PART_INSTALL/tmp
+      
       touch $CRAFT_PART_INSTALL/etc/ssl/certs/ca-certificates.crt
       touch $CRAFT_PART_INSTALL/etc/ca-certificates.conf
       for cert in /usr/share/ca-certificates/mozilla/* ; do
@@ -47,6 +53,8 @@ parts:
       done
       cp /usr/share/ca-certificates/mozilla/* $CRAFT_PART_INSTALL/usr/share/ca-certificates/mozilla
       cp /usr/sbin/update-ca-certificates $CRAFT_PART_INSTALL/usr/sbin/update-ca-certificates
+      chmod 777 $CRAFT_PART_INSTALL/tmp
+      chmod -R 777 $CRAFT_PART_INSTALL/etc/ssl/certs
 
   sed:
     plugin: nil


### PR DESCRIPTION
This pr adds the necessary script and packages to enable update-ca-certificates.

When ran for the first time update-ca-certificates output is:
```
$ update-ca-certificates
Updating certificates in /etc/ssl/certs...
rehash: warning: skipping ca-certificates.crt,it does not contain exactly one certificate or CRL
137 added, 0 removed; done.
```
This isn't supposed to be an issue.

After running it a second time, the output is:
```
$ update-ca-certificates
Updating certificates in /etc/ssl/certs...
0 added, 0 removed; done.
```
