### PR TITLE
chore: bump to 1.1.0

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: kratos
 base: bare
-build-base: ubuntu:22.04
-version: "1.0.0"
+build-base: ubuntu@22.04
+version: "1.1.0"
 summary: Ory Kratos identity server
 description: |
   Ory Kratos is an Identity and User Management system.
@@ -71,12 +71,12 @@ parts:
   kratos:
     plugin: go
     build-snaps:
-      - go/1.19/stable
+      - go/1.21/stable
     build-environment:
       - CGO_ENABLED: 0
     source: https://github.com/ory/kratos
     source-type: git
-    source-tag: v1.0.0
+    source-tag: v1.1.0
     override-build: |
       src_config_path="github.com/ory/kratos/driver"
       build_ver="${src_config_path}/config.Version"


### PR DESCRIPTION
This PR updates the kratos and go version.