### PR TITLE
Remove certificates from image

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -23,50 +23,11 @@ parts:
       # This is needed to pipe the stdout/stderr to a file for log forwarding and to update certificates
       - coreutils
 
-  openssl:
-    plugin: nil
-    stage-packages:
-      # This is needed to update certificates
-      - openssl
-
   shell:
     plugin: nil
     stage-packages:
       # This is needed to pipe the stdout/stderr to a file for log forwarding
       - dash
-
-  certificates:
-    plugin: nil
-    build-packages:
-      - ca-certificates
-    override-build: |
-      mkdir -p $CRAFT_PART_INSTALL/etc/ssl/certs
-      mkdir -p $CRAFT_PART_INSTALL/usr/share/ca-certificates/mozilla/
-      mkdir -p $CRAFT_PART_INSTALL/usr/sbin
-      mkdir -p $CRAFT_PART_INSTALL/tmp
-
-      touch $CRAFT_PART_INSTALL/etc/ssl/certs/ca-certificates.crt
-      touch $CRAFT_PART_INSTALL/etc/ca-certificates.conf
-      for cert in /usr/share/ca-certificates/mozilla/* ; do
-        echo "mozilla/$(basename $cert)" >> $CRAFT_PART_INSTALL/etc/ca-certificates.conf
-        cat "$cert" >> $CRAFT_PART_INSTALL/etc/ssl/certs/ca-certificates.crt
-      done
-      cp /usr/share/ca-certificates/mozilla/* $CRAFT_PART_INSTALL/usr/share/ca-certificates/mozilla
-      cp /usr/sbin/update-ca-certificates $CRAFT_PART_INSTALL/usr/sbin/update-ca-certificates
-      chmod 777 $CRAFT_PART_INSTALL/tmp
-      chmod -R 777 $CRAFT_PART_INSTALL/etc/ssl/certs
-
-  sed:
-    plugin: nil
-    stage-packages:
-      - sed
-
-  find:
-    plugin: nil
-    stage-packages:
-      - findutils
-    prime:
-      - usr/bin/find
 
   kratos:
     plugin: go


### PR DESCRIPTION
IAM-955

Closes #53

Reduces the image size from 95MB to 87MB. Have tested it with https://github.com/canonical/kratos-operator/pull/197