### PR TITLE
chore: GO111MODULE removed

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Golang setup
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.22.0'
+          go-version: ">=1.22.0"
       # install oci-factory via golang and set path in environment
       - name: Install oci-factory
         run: |
@@ -66,10 +66,8 @@ jobs:
           go install github.com/mikefarah/yq/v4@v4.44.3
           echo "OCI_FACTORY=$(go env GOPATH)/bin/oci-factory" >> $GITHUB_ENV
           echo "YQ=$(go env GOPATH)/bin/yq" >> $GITHUB_ENV
-        env:
-          GO111MODULE: "on"
       - name: Set EOLs and version
-        # special case for hydra due to the canonical fork  
+        # special case for hydra due to the canonical fork
         run: |
           echo EOL_STABLE=$(date -d "$(date +'%Y-%m-%d') +3 month" "+%Y-%m-%d") >> $GITHUB_ENV
           echo IMAGE_VERSION_STABLE=$($YQ '.version | split(".").0' rockcraft.yaml) >> $GITHUB_ENV
@@ -77,4 +75,4 @@ jobs:
         run: |
           $OCI_FACTORY upload -y --release track=$IMAGE_VERSION_STABLE-22.04,risks=stable,eol=$EOL_STABLE
         env:
-          GITHUB_TOKEN: ${{ secrets.token }}            
+          GITHUB_TOKEN: ${{ secrets.token }}


### PR DESCRIPTION
GO111MODULE param shouldn't be in use.

A couple of sources:

https://go.dev/blog/go116-module-changes#modules-on-by-default
https://maelvls.dev/go111module-everywhere/