### PR TITLE
chore: bump to v1.3.1

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 name: kratos
 base: bare
 build-base: ubuntu@22.04
-version: "1.3.0"
+version: "1.3.1"
 summary: Ory Kratos identity server
 description: |
   Ory Kratos is an Identity and User Management system.
@@ -37,7 +37,7 @@ parts:
       - CGO_ENABLED: "0"
     source: https://github.com/ory/kratos
     source-type: git
-    source-tag: v1.1.0
+    source-tag: v1.3.1
     override-build: |
       # Set the necessary flags
       src_config_path="github.com/ory/kratos/driver"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -32,7 +32,7 @@ parts:
   kratos:
     plugin: go
     build-snaps:
-      - go/1.21/stable
+      - go/1.23/stable
     build-environment:
       - CGO_ENABLED: "0"
     source: https://github.com/ory/kratos


### PR DESCRIPTION
We need to bump kratos to v1.3.1 because this patch release adds the ability to verify Android passkeys.